### PR TITLE
Addition of Unicode Characters Into the Testing Templates

### DIFF
--- a/api/api/user.py
+++ b/api/api/user.py
@@ -11,7 +11,7 @@ from api.common import WebException, InternalException
 from api.annotations import log_action
 from voluptuous import Required, Length, Schema
 
-_check_email_format = lambda email: re.match(r"[A-Za-z0-9\._%+-]+@[A-Za-z0-9\.-]+\.[A-Za-z]{2,4}", email) is not None
+_check_email_format = lambda email: re.match(r".+@.+\..{2,}", email) is not None
 
 user_schema = Schema({
     Required('email'): check(

--- a/api/tests/common.py
+++ b/api/tests/common.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 """
 Common Testing Functionality.
 """
@@ -7,7 +9,7 @@ import api
 from functools import wraps
 
 base_team = {
-    "team_name": "team",
+    "team_name": "team¢",
     "school": "Test HS",
     "password": "much_protected",
     "eligible": True
@@ -18,7 +20,7 @@ new_team_user = {
     "firstname": "Fred",
     "lastname": "Hacker",
     "password": "valid",
-    "email": "valid@hs.edu",
+    "email": "validʃ@hs.edu",
     "ctf-emails": False,
     "create-new-team": "true",
     "background": "student_hs",
@@ -30,19 +32,19 @@ new_team_user = {
 
 teacher_user = {
     "username": "valid",
-    "password": "valid",
+    "password": "valid❤",
     "firstname": "Mr. Fred",
     "lastname": "Hacker",
     "email": "valid@hs.edu",
     "background": "teacher",
     "create-new-teacher": "true",
-    "teacher-school": "Hacks HS",
+    "teacher-school": "µ Hacks HS",
     "country": "US",
     "ctf-emails": False
 }
 
 base_user = {
-    "username": "valid",
+    "username": "validµ",
     "firstname": "Fred",
     "lastname": "Hacker",
     "password": "valid",

--- a/api/tests/user_test.py
+++ b/api/tests/user_test.py
@@ -157,7 +157,7 @@ class TestUsers(object):
         assert tid, "Team was not created."
 
         uid = api.user.create_user_request(base_user.copy())
-        assert uid == api.user.get_user(name="valid")["uid"], "Good user created unsuccessfully."
+        assert uid == api.user.get_user(name=base_user["username"])["uid"], "Good user created unsuccessfully."
 
         with pytest.raises(WebException):
             api.user.create_user_request(base_user.copy())


### PR DESCRIPTION
I added Unicode characters to some choice fields in the testing templates. From this I was able to uncover there was a hardcoded value left from the deprecated tests in the current tests and the email filter did not support unicode characters or long TLDs. Fixes #20.