### PR TITLE
Team Score on Problem Page

### DIFF
--- a/web/_layouts/default.html
+++ b/web/_layouts/default.html
@@ -2,26 +2,26 @@
 <html lang="en" style="100%">
 
   {% include head.html %}
-    
+
 <body>
-        
-    {% include modal.html %}    
-    
+
+    {% include modal.html %}
+
     <div class="boxed">
         {% include header.html %}
 
 		{% if page.title_label != "hide" %}
 		<header class="page-title">
 			<div class="container">
-				<h1>{{ page.title }}</h1>	
+				<h1 id="title">{{ page.title }}</h1>
 			</div>
 		</header>
 		{% endif %}
-		
+
         <div id="main-content">
         {{ content }}
         </div>
-        
+
         {% include footer.html %}
 
         {% for js_file in page.post_scripts %}
@@ -34,7 +34,7 @@
                 {{ func }};
                 {% endfor %}
             })
-        </script>     
+        </script>
     </div>
 </body>
 </html>

--- a/web/coffee/problems.coffee
+++ b/web/coffee/problems.coffee
@@ -91,7 +91,10 @@ loadProblems = ->
       when 0
         apiNotify(data)
       when 1
-        addScoreToTitle("h1#title")
+      	# We want the score to be level with the title, but the title
+	# is defined in a template. This solution is therefore a bit
+	# of a hack.
+        addScoreToTitle("#title")
         apiCall "GET", "/api/problems/feedback/reviewed", {}
         .done (reviewData) ->
           $("#problem-list-holder").html renderProblemList({

--- a/web/coffee/problems.coffee
+++ b/web/coffee/problems.coffee
@@ -91,6 +91,7 @@ loadProblems = ->
       when 0
         apiNotify(data)
       when 1
+        addScoreToTitle("h1#title")
         apiCall "GET", "/api/problems/feedback/reviewed", {}
         .done (reviewData) ->
           $("#problem-list-holder").html renderProblemList({
@@ -124,5 +125,11 @@ loadProblems = ->
 
           $(".problem-review-form").on "submit", addProblemReview
 
+addScoreToTitle = (selector) ->
+        apiCall "GET", "/api/team/score", {}
+        .done (data) ->
+          if data.data
+            $(selector).children("#team-score").remove()
+            $(selector).append("<span id='team-score' class='pull-right'>Score: " + data.data.score + "</span>")
 $ ->
   loadProblems()


### PR DESCRIPTION
This branch adds the team's score to the problem page. I believe this is the request of #5 and should close #5.

This is a bit of a hack and I'd be interested in other ways of doing this. The problem is that Jekyll renders that part of the page. In the usual case, you would just edit your underscore template to include the additional information. In this case, I let Jekyll render it and then on load modify the DOM.

![score](https://cloud.githubusercontent.com/assets/5132014/6583244/2141bc9a-c739-11e4-922a-a8491b9f728e.png)
