### PR TITLE
Allow setup script to run from non-vagrant systems

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -52,7 +52,7 @@ There are many other useful [Vagrant commands](http://docs.vagrantup.com/v2/cli/
 
 
 ###<a name="devenv-novagrant"></a>  What if I don't want to use Vagrant?
-You do not need to use either Vagrant or VirtualBox to run the picoCTF Platform. This is purely to ease development. You can always run the picoCTF Platform directly on Ubuntu 14.04 or a similar Linux distribution by running the `scripts/vagrant_setup.sh` directly on the target machine (as root). This is the recommended approach for setting up the picoCTF Platform on a production server.
+You do not need to use either Vagrant or VirtualBox to run the picoCTF Platform. This is purely to ease development. You can always run the picoCTF Platform directly on Ubuntu 14.04 or a similar Linux distribution by running the `scripts/non_vagrant_setup.sh` directly on the target machine (as root). This is the recommended approach for setting up the picoCTF Platform on a production server.
 
 
 ## <a name="starting"></a> Starting the picoCTF Platform ##

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,7 @@ true
   config.vm.synced_folder "api", "/home/vagrant/api"
   config.vm.synced_folder "web", "/home/vagrant/web"
   config.vm.synced_folder "scripts", "/home/vagrant/scripts"
+  config.vm.synced_folder "config", "/home/vagrant/config"
   config.vm.provision :shell, :path => "scripts/vagrant_setup.sh"
   config.ssh.forward_agent = true
 

--- a/scripts/devploy
+++ b/scripts/devploy
@@ -1,8 +1,16 @@
 #!/bin/bash
 
+PICOCTF_HOME=${PICOCTF_HOME:-'/home/vagrant/'}
+
+if [ ! -d "$PICOCTF_HOME" ]; then
+	echo "$PICOCTF_HOME does not exist."
+	echo "Please set PICOCTF_HOME to the picoCTF-Platform-2 directory"
+	exit 1
+fi
+
 # Transpile the CoffeeScript files
 echo "Transpiling Coffeescript"
-coffee -c -o /home/vagrant/web/js/ /home/vagrant/web/coffee/
+coffee -c -o ${PICOCTF_HOME}/web/js/ ${PICOCTF_HOME}/web/coffee/
 
 # Shutdown the server
 echo "Shutting down nginx"
@@ -13,13 +21,13 @@ echo "Cleaning up old files"
 sudo rm -rf /srv/http/ctf/*
 
 echo "Generating web with Jekyll"
-cd /home/vagrant/web
+cd ${PICOCTF_HOME}/web
 sudo jekyll build
 
 echo "Copying files to server"
-#sudo cp -r /home/vagrant/web/* /srv/http/ctf/
-mkdir -p /home/vagrant/problem_static
-sudo cp -r /home/vagrant/problem_static /srv/http/ctf/problem-static
+#sudo cp -r ${PICOCTF_HOME}/web/* /srv/http/ctf/
+mkdir -p ${PICOCTF_HOME}/problem_static
+sudo cp -r ${PICOCTF_HOME}/problem_static /srv/http/ctf/problem-static
 
 # Make sure everything is in UNIX format.
 sudo dos2unix -q /srv/http/ctf/*.html
@@ -30,9 +38,9 @@ sudo service nginx start
 
 # Clear the cache
 echo "Clearing the API cache"
-/home/vagrant/api/api_manager.py database clear cache
+${PICOCTF_HOME}/api/api_manager.py database clear cache
 
 #Start picoCTF API
 echo "Starting the picoCTF API"
 tmux kill-session -t picoapi 2> /dev/null
-tmux new-session -s picoapi -d "cd /home/vagrant/api && python3 run.py"
+tmux new-session -s picoapi -d "cd ${PICOCTF_HOME}/api && python3 run.py"

--- a/scripts/non_vagrant_setup.sh
+++ b/scripts/non_vagrant_setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# cd to the picoCTF-Platform-2 directory
+# (This assumes this script is in picoCTF-Platform-2/scripts)
+cd `dirname "$(readlink -f "$0")"`
+cd ..
+
+# Configure PICOCTF_HOME for subsequent invocations of devploy script
+echo "export PICOCTF_HOME=`pwd`" >> /etc/profile
+
+PICOCTF_HOME=`pwd` scripts/vagrant_setup.sh

--- a/scripts/vagrant_setup.sh
+++ b/scripts/vagrant_setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+PICOCTF_HOME=${PICOCTF_HOME:-'/home/vagrant/'}
+
 # Updates
 apt-get -y update
 apt-get -y upgrade
@@ -23,16 +25,16 @@ npm install -g coffee-script
 npm install -g react-tools
 npm install -g jsxhint
 
-pip3 install -r /home/vagrant/api/requirements.txt
+pip3 install -r ${PICOCTF_HOME}/api/requirements.txt
 
 # Jekyll
 gem install jekyll -v 2.5.3
 
 # Configure Environment
-echo 'PATH=$PATH:/home/vagrant/scripts' >> /etc/profile
+echo 'PATH=$PATH:${PICOCTF_HOME}/scripts' >> /etc/profile
 
 # Configure Nginx
-cp /vagrant/config/ctf.nginx /etc/nginx/sites-enabled/ctf
+cp ${PICOCTF_HOME}/config/ctf.nginx /etc/nginx/sites-enabled/ctf
 rm /etc/nginx/sites-enabled/default
 mkdir -p /srv/http/ctf
 service nginx restart

--- a/scripts/vagrant_setup.sh
+++ b/scripts/vagrant_setup.sh
@@ -31,7 +31,7 @@ pip3 install -r ${PICOCTF_HOME}/api/requirements.txt
 gem install jekyll -v 2.5.3
 
 # Configure Environment
-echo 'PATH=$PATH:${PICOCTF_HOME}/scripts' >> /etc/profile
+echo "PATH=\$PATH:${PICOCTF_HOME}/scripts" >> /etc/profile
 
 # Configure Nginx
 cp ${PICOCTF_HOME}/config/ctf.nginx /etc/nginx/sites-enabled/ctf


### PR DESCRIPTION
- Replaced references to `/home/vagrant` with `$PICOCTF_HOME` in `vagrant_setup.sh` and `devploy`
- Added `non_vagrant_setup.sh` to set `PICOCTF_HOME` and call `vagrant_setup.sh`