### PR TITLE
Added nginx config folder to vagrant synced folders

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,7 @@ true
 true
   config.vm.synced_folder "api", "/home/vagrant/api"
   config.vm.synced_folder "web", "/home/vagrant/web"
+  config.vm.synced_folder "config", "/home/vagrant/config"
   config.vm.synced_folder "scripts", "/home/vagrant/scripts"
   config.vm.provision :shell, :path => "scripts/vagrant_setup.sh"
   config.ssh.forward_agent = true


### PR DESCRIPTION
Hi there,

the Vagrantfile misses the ```config``` folder, this leads to nginx not beeing configured, therefore the API proxy won't start.

The vagrant_setup.sh shows this by printing:

    cp: cannot stat ‘/home/vagrant/config/ctf.nginx’: No such file or directory

at the vagrant provisioning with ```vagrant up```.

I fixed this by adding the config dir to the Vagrantfile.